### PR TITLE
Remove pre-commit from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ django==3.0
 djangorestframework==3.10.0
 marshmallow==3.5.2
 pika==1.1.0
-pre-commit==2.3.0
 python-decouple==3.3
 retry==0.9.2
 mkdocs==1.0.4


### PR DESCRIPTION
This pull request removes the *pre-commit* from requirements removing unnecessary dependencies since we're using *pre-commit* only in local development environments.

P.S. All *pre-commit* instructions will be visible for the developers after merging the pull request #15 